### PR TITLE
feat: add sortAttributes option

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -263,3 +263,16 @@ test('should not strip out conditional comments', () => {
 `
   );
 });
+
+test('should sort attributes with `sortAttributes` function', () => {
+  const html = `<input name="test" value="true" class="form-control">`;
+  const sortAttributes = (names) => names.sort();
+  expect(format(html, { sortAttributes })).toEqual(
+    `
+<input class="form-control"
+       name="test"
+       value="true"
+>
+`
+  );
+});

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const voidElements = [
   'wbr',
 ];
 
-const format = function(html) {
+const format = function(html, { sortAttributes } = {}) {
   const elements = [];
   const indentSize = 2;
 
@@ -109,7 +109,10 @@ const format = function(html) {
   };
 
   const appendAttributes = (attributes, tagName) => {
-    const names = Object.keys(attributes);
+    let names = Object.keys(attributes);
+    if (typeof sortAttributes === 'function') {
+      names = sortAttributes(names);
+    }
 
     if (names.length === 1) {
       appendAttribute(names[0], attributes[names[0]]);
@@ -120,7 +123,7 @@ const format = function(html) {
     }
 
     let firstAttribute = true;
-    for (let name in attributes) {
+    for (let name of names) {
       if (firstAttribute === true) {
         firstAttribute = false;
         appendAttribute(name, attributes[name]);

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const voidElements = [
   'wbr',
 ];
 
-const format = function(html, { sortAttributes } = {}) {
+const format = function(html, { sortAttributes = names => names } = {}) {
   const elements = [];
   const indentSize = 2;
 
@@ -109,10 +109,7 @@ const format = function(html, { sortAttributes } = {}) {
   };
 
   const appendAttributes = (attributes, tagName) => {
-    let names = Object.keys(attributes);
-    if (typeof sortAttributes === 'function') {
-      names = sortAttributes(names);
-    }
+    const names = sortAttributes(Object.keys(attributes));
 
     if (names.length === 1) {
       appendAttribute(names[0], attributes[names[0]]);


### PR DESCRIPTION
## Summary

This PR adds `sortAttributes` option.

It's an optional function that takes `names` and returns a sorted `names`.
When not given, it doesn't change anything, so it's not a breaking change.